### PR TITLE
feat: remove treasure chest from the game (#32)

### DIFF
--- a/client/src/components/BoardSection.vue
+++ b/client/src/components/BoardSection.vue
@@ -10,8 +10,6 @@
                 class="flex flex-[2] overflow-hidden border-t-2 border-gray-300 bg-neutral-700 p-4">
                 <TacticsBoard class="w-1/2 overflow-y-auto pr-2" />
                 <SkillSelection class="flex w-1/2 flex-col pl-2" :tabs="tabs" :cards="filteredCards" />
-                <SpriteButton sprite-src="assets/chests.png" :scale="4" :col="0" :row="0"
-                    className="absolute bottom-40 left-0" :action="openSkillModal" />
             </div>
             <button v-show="currentScene === 'BattleScene'" @click="openSkillModal" class="btn">
                 Open Skill Modal


### PR DESCRIPTION
# 概要
ホーム画面に表示されていた設定ボタンを削除しました。

# 背景・理由
機能整理により現在は使用されておらず、UIの簡素化のため不要と判断しました。

# 対応内容
BoardSection.vue 内の <SpriteButton> を削除

# 関連するスタイルとロジックも削除

# 備考
本PRは #32 に対応しています。