### PR TITLE
fix(result-scene): hide Vue devtools when transitioning to result screen

### DIFF
--- a/client/src/scenes/ResultScene.js
+++ b/client/src/scenes/ResultScene.js
@@ -15,6 +15,8 @@ export class ResultScene extends Phaser.Scene {
     }
 
     create() {
+        phaserEvents.emit('scene-changed', this.scene.key);
+
         this.scale.resize(1440, 810);
 
         const displayText = this.winner === 'draw' ? '相打ち！' : `${this.winner}`;


### PR DESCRIPTION
Hide the Vue control panel upon entering the result scene to improve UI presentation.

Close #46 