### PR TITLE
fix: Prevent unnecessary modal after skill selection

### DIFF
--- a/client/src/components/modals/ModalBase.vue
+++ b/client/src/components/modals/ModalBase.vue
@@ -1,11 +1,6 @@
 <template>
     <div v-if="visible" class="fixed inset-0 z-50 flex items-center justify-center bg-black/50" @click.self="close">
-        <slot name="container">
-            <div class="relative bg-white rounded-xl shadow-xl w-full max-w-4xl p-6">
-                <button class="absolute top-2 right-2 text-gray-400 hover:text-gray-600" @click="close">×</button>
-                <slot />
-            </div>
-        </slot>
+        <slot />
     </div>
 </template>
 

--- a/client/src/components/modals/SkillSelectModal.vue
+++ b/client/src/components/modals/SkillSelectModal.vue
@@ -1,25 +1,21 @@
 <template>
-    <BaseModal :visible="show" @close="show = false">
-        <template #container>
-            <div class="relative bg-yellow-100 border-2 border-yellow-400 rounded-lg p-10">
-                <button class="absolute top-2 right-2 text-red-500" @click="show = false">×</button>
-                <div class="space-y-4">
-                    <h2 class="text-lg font-bold">Select a Skill</h2>
-                    <div class="gap-2">
-                        <div v-for="card in cards" :key="card.id"
-                            class="w-full max-w-4xl p-4 border rounded cursor-pointer hover:bg-blue-100"
-                            :class="{ 'bg-blue-200': selected?.id === card.id }" @click="select(card)">
-                            <Card :card="card" />
-                        </div>
-                    </div>
-                    <div class="flex justify-end space-x-2">
-                        <button @click="$emit('cancel')" class="btn-secondary">Cancel</button>
-                        <button @click="confirm" :disabled="!selected" class="btn-primary">Confirm</button>
-                    </div>
+    <div class="relative bg-yellow-100 border-2 border-yellow-400 rounded-lg p-10">
+        <button class="absolute top-2 right-2 text-red-500" @click="$emit('cancel')">×</button>
+        <div class="space-y-4">
+            <h2 class="text-lg font-bold">Select a Skill</h2>
+            <div class="gap-2">
+                <div v-for="card in cards" :key="card.id"
+                    class="w-full max-w-4xl p-4 border rounded cursor-pointer hover:bg-blue-100"
+                    :class="{ 'bg-blue-200': selected?.id === card.id }" @click="select(card)">
+                    <Card :card="card" />
                 </div>
             </div>
-        </template>
-    </BaseModal>
+            <div class="flex justify-end space-x-2">
+                <button @click="$emit('cancel')" class="btn-secondary">Cancel</button>
+                <button @click="confirm" :disabled="!selected" class="btn-primary">Confirm</button>
+            </div>
+        </div>
+    </div>
 </template>
 
 <script setup>


### PR DESCRIPTION
Corrected the logic in `ModalBase.vue` and `SkillSelectModal.vue` to ensure an extraneous modal no longer appears immediately after a skill is chosen.