### PR TITLE
feat: Initiate BattleScene fade-in before game join

### DIFF
--- a/client/src/scenes/BattleScene.js
+++ b/client/src/scenes/BattleScene.js
@@ -44,12 +44,13 @@ export class BattleScene extends Phaser.Scene {
         this.bgmManager = new BgmManager(this);
         this.bgmManager.play(this.scene.key, bgmMap);
 
+        this.effectManager.fadeIn();
+
         await this.colyseus.join(() => {
             this.readyButton.show();
         });
 
         // sm.playBgm('bgm_battle');
-        this.effectManager.fadeIn();
 
         this.events.once(Phaser.Scenes.Events.SHUTDOWN, this.cleanup, this);
     }


### PR DESCRIPTION
Adjusted BattleScene logic to trigger the fade-in animation prior to the player officially joining the game, ensuring a smoother visual transition.