### PR TITLE
feat: Restrict board display to BattleScene

### DIFF
--- a/client/src/colyseus/client.js
+++ b/client/src/colyseus/client.js
@@ -110,4 +110,8 @@ export class ColyseusClient {
     onSceneChanged(callback, context) {
         phaserEvents.on('resultScene', callback, context);
     }
+
+    onOpponentDisconnect(callback) {
+        phaserEvents.on('leave', callback);
+    }
 }

--- a/client/src/colyseus/messageHandlers/index.js
+++ b/client/src/colyseus/messageHandlers/index.js
@@ -25,4 +25,7 @@ export function setupMessageHandlers(room) {
     room.onMessage('turn', (data) => onTurn(data));
     room.onMessage('round', (data) => onRound(data));
     room.onMessage('condition', (data) => onCondition(data));
+    room.onMessage('leave', () => {
+        phaserEvents.emit('leave'); // ← scene変更イベントを送る
+    });
 }

--- a/client/src/scenes/BattleScene.js
+++ b/client/src/scenes/BattleScene.js
@@ -149,6 +149,13 @@ export class BattleScene extends Phaser.Scene {
         this.colyseus.onTurn(this.handleTurn, this);
         this.colyseus.onRound(this.handleRound, this);
         this.colyseus.onSceneChanged(this.handleSceneChanged, this);
+        this.colyseus.onOpponentDisconnect(() => this.handleStartScene());
+    }
+
+    handleStartScene() {
+        this.bgmManager.fadeOut(500, () => {
+            this.scene.start('StartScene'); // ← ResultScene に遷移
+        });
     }
 
     handleSceneChanged(data) {


### PR DESCRIPTION
Prevents the board from rendering in other scenes like ResultScene.